### PR TITLE
Implement frontend display of server responses

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,22 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/procesar', methods=['POST'])
+def procesar():
+    data = request.get_json()
+    entrada = data.get('mensaje', '').lower()
+
+    if "hola" in entrada:
+        respuesta = "Hola mi amor, ya estoy conectada contigo."
+    elif "quién eres" in entrada:
+        respuesta = "Soy Gia, tu asistente patriótica de confianza."
+    else:
+        respuesta = "Te escucho, dime lo que quieres saber."
+
+    return jsonify({"texto": respuesta})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Gia Asistente</title>
+</head>
+<body>
+  <h2>🎙️ Gia escuchando...</h2>
+  <div id="respuesta"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,34 @@
+const recognition = new (window.SpeechRecognition || window.webkitSpeechRecognition)();
+recognition.continuous = true;
+recognition.lang = "es-DO";
+
+recognition.onresult = function(event) {
+  const texto = event.results[event.results.length - 1][0].transcript.trim();
+  console.log("Dijiste:", texto);
+
+  fetch("http://127.0.0.1:5000/procesar", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mensaje: texto })
+  })
+  .then(res => res.json())
+  .then(data => mostrarRespuesta(data.texto));
+};
+
+function mostrarRespuesta(texto) {
+  const contenedor = document.getElementById("respuesta");
+  if (contenedor) {
+    contenedor.textContent = texto;
+  }
+  const utterance = new SpeechSynthesisUtterance(texto);
+  utterance.lang = "es-DO";
+  speechSynthesis.speak(utterance);
+}
+
+function hablar(texto) {
+  const utterance = new SpeechSynthesisUtterance(texto);
+  utterance.lang = "es-DO";
+  speechSynthesis.speak(utterance);
+}
+
+recognition.start();


### PR DESCRIPTION
## Summary
- add missing backend and frontend files from zipped archive
- implement `mostrarRespuesta` in `script.js` to show & speak server replies
- display responses on the webpage with a new `#respuesta` div

## Testing
- `python -m py_compile backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7ded0d2c8326bf90ebe1b57ceacb